### PR TITLE
Improvements/fixes to grab-lfs code on Linux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Added
 
-Nothing!
+Two updates:
+
+- Adds a missing .split() call needed to run a bash command.
+- Adds a lock when downloading gif lfs so that multiple processes don't try to do this simultaneously.
 
 # Changelog
 

--- a/prior/__init__.py
+++ b/prior/__init__.py
@@ -116,7 +116,7 @@ def _get_git_lfs_cmd():
             )
 
             if download_path.endswith(".tar.gz"):
-                subprocess.check_output(f"tar xvfz {download_path}")
+                subprocess.check_output(f"tar xvfz {download_path}".split())
             elif download_path.endswith(".zip"):
                 with zipfile.ZipFile(download_path, "r") as zip_ref:
                     zip_ref.extractall(DATASET_DIR)

--- a/prior/__init__.py
+++ b/prior/__init__.py
@@ -112,7 +112,8 @@ def _get_git_lfs_cmd():
                 expected_sha = _LFS_FILE_TO_SHA256[os.path.basename(download_path)]
 
                 assert found_sha == expected_sha, (
-                    f"sha-256 hashes do not match for {download_path}. Expected: {expected_sha}, found {found_sha}."
+                    f"sha-256 hashes do not match for {download_path}."
+                    f" Expected: {expected_sha}, found {found_sha}."
                     f" Was there an error when downloading?"
                 )
 


### PR DESCRIPTION
Two updates:
1. Adds a missing `.split()` call needed to run a bash command.
2. Adds a lock when downloading gif lfs so that multiple processes don't try to do this simultaneously.