### PR TITLE
Support loading models

### DIFF
--- a/prior/__init__.py
+++ b/prior/__init__.py
@@ -6,7 +6,7 @@ import platform
 import stat
 import subprocess
 import zipfile
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import requests
 from github import Github, GithubException
@@ -137,7 +137,9 @@ def _get_git_lfs_cmd():
         return git_lfs_path
 
 
-def _clone_repo(base_dir: str, entity: str, project: str, revision: str, offline: bool) -> None:
+def _clone_repo(
+    base_dir: str, entity: str, project: str, revision: str, offline: bool
+) -> Tuple[str, str]:
     def get_cached_sha() -> Optional[str]:
         if os.path.exists(f"{project_dir}/cache"):
             with LockEx(f"{project_dir}/cache-lock"):
@@ -445,7 +447,7 @@ def load_model(
 
         out: Dict[str, Any] = {}
         exec(open(f"{models_path}/main.py").read(), out)
-        model_path: DatasetDict = out["load_model"](model=model, **kwargs)
+        model_path: str = out["load_model"](model=model, **kwargs)
         os.chdir(start_dir)
     finally:
         os.environ["PATH"] = oldpath

--- a/prior/__init__.py
+++ b/prior/__init__.py
@@ -350,14 +350,16 @@ def load_model(
     """Load the dataset from the given revision.
 
     Args:
-        dataset: The name of the dataset to load.
+        project: The name of the project to load (e.g., "procthor-models").
+            This is the name of the GitHub repository.
+        model: The name of the model to load. Names are specified as the keys
+            within the project's models.json file.
         revision: The git revision of the dataset to load. Can be specified as either
             a commit id sha, tag, or branch. If None, the latest commit to main
             will be used.
         entity: The github organization or username that has the dataset.
         offline: If True, don't attempt to download the dataset from github.
-        kwargs: Allows you to specify variants of a particular dataset (e.g., do you
-            want the variant with a locobot or a different agent?).
+        kwargs: Allows you to specify variants of a particular model.
 
     Returns:
         A DatasetDict containing the loaded dataset.

--- a/prior/__init__.py
+++ b/prior/__init__.py
@@ -137,29 +137,7 @@ def _get_git_lfs_cmd():
         return git_lfs_path
 
 
-def load_dataset(
-    dataset: str,
-    revision: str = "main",
-    entity: str = "allenai",
-    offline: bool = False,
-    **kwargs: Any,
-) -> DatasetDict:
-    """Load the dataset from the given revision.
-
-    Args:
-        dataset: The name of the dataset to load.
-        revision: The git revision of the dataset to load. Can be specified as either
-            a commit id sha, tag, or branch. If None, the latest commit to main
-            will be used.
-        entity: The github organization or username that has the dataset.
-        offline: If True, don't attempt to download the dataset from github.
-        kwargs: Allows you to specify variants of a particular dataset (e.g., do you
-            want the variant with a locobot or a different agent?).
-
-    Returns:
-        A DatasetDict containing the loaded dataset.
-    """
-
+def _clone_repo(entity: str, project: str, revision: str, offline: bool) -> None:
     def get_cached_sha() -> Optional[str]:
         if os.path.exists(f"{dataset_dir}/cache"):
             with LockEx(f"{dataset_dir}/cache-lock"):
@@ -169,204 +147,8 @@ def load_dataset(
                     return cache[revision]
         return None
 
-    dataset_dir = f"{DATASET_DIR}/{entity}/{dataset}"
+    dataset_dir = f"{DATASET_DIR}/{entity}/{project}"
     os.makedirs(dataset_dir, exist_ok=True)
-    start_dir = os.getcwd()
-
-    sha: str
-    cached_sha: Optional[str]
-    token: str = ""
-
-    if os.path.exists(f"{dataset_dir}/{revision}"):
-        # If the dataset is already downloaded, use the cached sha.
-        # NOTE: this will only occur if a commit id is passed in.
-        # Otherwise, it tries to find the commit id.
-        # NOTE: Not sure how it handles amend commits...
-        sha = revision
-    elif offline:
-        cached_sha = get_cached_sha()
-        if cached_sha is None or not os.path.isdir(f"{dataset_dir}/{cached_sha}"):
-            raise ValueError(
-                f"Offline dataset {dataset} is not downloaded "
-                f"for revision {revision}. "
-                f" cached_sha={cached_sha}, dataset_dir={dataset_dir}"
-            )
-        sha = cached_sha
-        logging.debug(f"Using offline dataset {dataset} for revision {revision} with sha {sha}.")
-    else:
-        res = requests.get(
-            f"https://api.github.com/repos/{entity}/{dataset}/commits?sha={revision}"
-        )
-        logging.debug(f"Getting status code {res.status_code} for {revision}")
-        if res.status_code == 404 or res.status_code == 403:
-            # Try using private repo.
-            if (
-                not os.path.exists(f"{os.environ['HOME']}/.git-credentials")
-                and gh_auth_token is None
-                and "GITHUB_TOKEN" not in os.environ
-            ):
-                # try using cache
-                cached_sha = None
-                if res.status_code == 403:
-                    cached_sha = get_cached_sha()
-                    if cached_sha is not None:
-                        logging.debug("Exceeded API limit, using cached sha.")
-                elif cached_sha is None:
-                    raise Exception(
-                        "Could not find dataset.\n"
-                        "If you're using a private repo, "
-                        "override the github auth token with:\n"
-                        "    import prior\n"
-                        "    prior.gh_auth_token = <token>\n"
-                        "Alternatively, you can set the environment variable with:\n"
-                        "    export GITHUB_TOKEN=<token>\n"
-                        "from the command line."
-                    )
-
-            if gh_auth_token is not None:
-                # Treats gh_auth_token as a string
-                token = gh_auth_token.strip()  # type: ignore
-            elif os.environ.get("GITHUB_TOKEN") is not None:
-                token = os.environ["GITHUB_TOKEN"].strip()
-            else:
-                # look at ~/.git-credentials
-                with open(f"{os.environ['HOME']}/.git-credentials", "r") as f:
-                    tokens = f.read()
-                token = next(token for token in tokens.split("\n") if token.endswith("github.com"))
-                token = token.split(":")[2]
-                token = token.split("@")[0]
-
-            g = Github(token)
-            repo = g.get_repo(f"{entity}/{dataset}")
-
-            # if revision is a commit_id, branch, or tag use it
-            try:
-                sha = repo.get_commits(sha=revision)[0].sha
-            except GithubException:
-                raise GithubException(
-                    f"Could not find revision={revision} in dataset={entity}/{dataset}."
-                    " Please pass a valid commit_id sha, branch name, or tag."
-                )
-        elif res.status_code == 200:
-            sha = res.json()[0]["sha"]
-        else:
-            raise Exception(f"Unknown GitHub API status code: {res.status_code}")
-
-        with LockEx(f"{dataset_dir}/cache-lock"):
-            if os.path.exists(f"{dataset_dir}/cache"):
-                with open(f"{dataset_dir}/cache", "r") as f:
-                    cache = json.load(f)
-            else:
-                cache = {}
-            with open(f"{dataset_dir}/cache", "w") as f:
-                cache[revision] = sha
-                json.dump(cache, f)
-
-    git_lfs_cmd = _get_git_lfs_cmd()
-    oldpath = os.environ["PATH"]
-    try:
-        # The below PATH setting needs to happen before running any git commands as otherwise git
-        # will not see the git-lfs download which causes all sorts of weird issues.
-        if git_lfs_cmd != "git lfs":
-            # Need to set the path so that git sees git-lfs below
-            os.environ["PATH"] = f'{os.environ["PATH"]}:{os.path.dirname(git_lfs_cmd)}'
-
-        # download the dataset
-        dataset_path = f"{dataset_dir}/{sha}"
-        if not os.path.exists(dataset_path):
-            with LockEx(f"{dataset_dir}/lock"):
-                logging.debug(
-                    f"Downloading dataset {dataset} at revision {revision} to {dataset_path}."
-                )
-                token_prefix = f"{token}@" if token else ""
-                subprocess.run(
-                    args=[
-                        "git",
-                        "clone",
-                        f"https://{token_prefix}github.com/{entity}/{dataset}.git",
-                        dataset_path,
-                    ],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
-                logging.debug(f"Downloaded dataset to {dataset_path}")
-                # change the subprocess working directory to the dataset directory
-                os.chdir(dataset_path)
-                subprocess.run(
-                    args=["git", "checkout", sha],
-                    stderr=subprocess.DEVNULL,
-                    stdout=subprocess.DEVNULL,
-                )
-                logging.debug(f"Checked out {sha}")
-
-                subprocess.run(
-                    args="git restore --staged .".split(),
-                    stderr=subprocess.DEVNULL,
-                    stdout=subprocess.DEVNULL,
-                )
-
-        logging.debug(f"Using dataset {dataset} at revision {revision} in {dataset_path}.")
-        os.chdir(dataset_path)
-
-        out: Dict[str, Any] = {}
-
-        out0 = subprocess.run(
-            f"{git_lfs_cmd} install".split(),
-            stdout=subprocess.DEVNULL,
-        )
-        out1 = subprocess.run(
-            f"{git_lfs_cmd} fetch origin".split(),
-            stdout=subprocess.DEVNULL,
-        )
-        out2 = subprocess.run(f"{git_lfs_cmd} checkout".split(), stdout=subprocess.DEVNULL)
-
-        assert out0.returncode == out1.returncode == out2.returncode == 0
-
-        exec(open(f"{dataset_path}/main.py").read(), out)
-        out_dataset: DatasetDict = out["load_dataset"](**kwargs)
-        os.chdir(start_dir)
-    finally:
-        os.environ["PATH"] = oldpath
-
-    return out_dataset
-
-
-def load_model(
-    project: str,
-    model: str,
-    entity: str = "allenai",
-    revision: str = "main",
-    offline: bool = False,
-    **kwargs,
-) -> str:
-    """Load the dataset from the given revision.
-
-    Args:
-        dataset: The name of the dataset to load.
-        revision: The git revision of the dataset to load. Can be specified as either
-            a commit id sha, tag, or branch. If None, the latest commit to main
-            will be used.
-        entity: The github organization or username that has the dataset.
-        offline: If True, don't attempt to download the dataset from github.
-        kwargs: Allows you to specify variants of a particular dataset (e.g., do you
-            want the variant with a locobot or a different agent?).
-
-    Returns:
-        A DatasetDict containing the loaded dataset.
-    """
-
-    def get_cached_sha() -> Optional[str]:
-        if os.path.exists(f"{dataset_dir}/cache"):
-            with LockEx(f"{dataset_dir}/cache-lock"):
-                with open(f"{dataset_dir}/cache", "r") as f:
-                    cache = json.load(f)
-                if revision in cache:
-                    return cache[revision]
-        return None
-
-    dataset_dir = f"{MODEL_DIR}/{entity}/{project}"
-    os.makedirs(dataset_dir, exist_ok=True)
-    start_dir = os.getcwd()
 
     sha: str
     cached_sha: Optional[str]
@@ -439,7 +221,7 @@ def load_model(
                 sha = repo.get_commits(sha=revision)[0].sha
             except GithubException:
                 raise GithubException(
-                    f"Could not find revision={revision} in model={entity}/{project}."
+                    f"Could not find revision={revision} in project={entity}/{project}."
                     " Please pass a valid commit_id sha, branch name, or tag."
                 )
         elif res.status_code == 200:
@@ -457,6 +239,36 @@ def load_model(
                 cache[revision] = sha
                 json.dump(cache, f)
 
+    return sha, token
+
+
+def load_dataset(
+    dataset: str,
+    revision: str = "main",
+    entity: str = "allenai",
+    offline: bool = False,
+    **kwargs: Any,
+) -> DatasetDict:
+    """Load the dataset from the given revision.
+
+    Args:
+        dataset: The name of the dataset to load.
+        revision: The git revision of the dataset to load. Can be specified as either
+            a commit id sha, tag, or branch. If None, the latest commit to main
+            will be used.
+        entity: The github organization or username that has the dataset.
+        offline: If True, don't attempt to download the dataset from github.
+        kwargs: Allows you to specify variants of a particular dataset (e.g., do you
+            want the variant with a locobot or a different agent?).
+
+    Returns:
+        A DatasetDict containing the loaded dataset.
+    """
+
+    start_dir = os.getcwd()
+    project_dir = f"{DATASET_DIR}/{entity}/{dataset}"
+    sha, token = _clone_repo(entity=entity, project=dataset, revision=revision, offline=offline)
+
     git_lfs_cmd = _get_git_lfs_cmd()
     oldpath = os.environ["PATH"]
     try:
@@ -467,30 +279,23 @@ def load_model(
             os.environ["PATH"] = f'{os.environ["PATH"]}:{os.path.dirname(git_lfs_cmd)}'
 
         # download the dataset
-        dataset_path = f"{dataset_dir}/{sha}"
+        dataset_path = f"{project_dir}/{sha}"
         if not os.path.exists(dataset_path):
-            with LockEx(f"{dataset_dir}/lock"):
+            with LockEx(f"{project_dir}/lock"):
                 logging.debug(
-                    f"Downloading project {project} at revision {revision} to {dataset_path}."
+                    f"Downloading dataset {dataset} at revision {revision} to {dataset_path}."
                 )
                 token_prefix = f"{token}@" if token else ""
-
-                # using smudges avoid downloading all LFS files / weights
-                old_smudge_value = os.environ.get("GIT_LFS_SKIP_SMUDGE", None)
-                os.environ["GIT_LFS_SKIP_SMUDGE"] = "1"
                 subprocess.run(
                     args=[
                         "git",
                         "clone",
-                        f"https://{token_prefix}github.com/{entity}/{project}.git",
+                        f"https://{token_prefix}github.com/{entity}/{dataset}.git",
                         dataset_path,
                     ],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )
-                if old_smudge_value is not None:
-                    os.environ["GIT_LFS_SKIP_SMUDGE"] = old_smudge_value
-
                 logging.debug(f"Downloaded dataset to {dataset_path}")
                 # change the subprocess working directory to the dataset directory
                 os.chdir(dataset_path)
@@ -507,10 +312,111 @@ def load_model(
                     stdout=subprocess.DEVNULL,
                 )
 
-        logging.debug(f"Using project {project} at revision {revision} in {dataset_path}.")
+        logging.debug(f"Using dataset {dataset} at revision {revision} in {dataset_path}.")
         os.chdir(dataset_path)
 
+        out0 = subprocess.run(
+            f"{git_lfs_cmd} install".split(),
+            stdout=subprocess.DEVNULL,
+        )
+        out1 = subprocess.run(
+            f"{git_lfs_cmd} fetch origin".split(),
+            stdout=subprocess.DEVNULL,
+        )
+        out2 = subprocess.run(f"{git_lfs_cmd} checkout".split(), stdout=subprocess.DEVNULL)
+
+        assert out0.returncode == out1.returncode == out2.returncode == 0
+
         out: Dict[str, Any] = {}
+        exec(open(f"{dataset_path}/main.py").read(), out)
+        out_dataset: DatasetDict = out["load_dataset"](**kwargs)
+        os.chdir(start_dir)
+    finally:
+        os.environ["PATH"] = oldpath
+
+    return out_dataset
+
+
+def load_model(
+    project: str,
+    model: str,
+    entity: str = "allenai",
+    revision: str = "main",
+    offline: bool = False,
+    **kwargs,
+) -> str:
+    """Load the dataset from the given revision.
+
+    Args:
+        dataset: The name of the dataset to load.
+        revision: The git revision of the dataset to load. Can be specified as either
+            a commit id sha, tag, or branch. If None, the latest commit to main
+            will be used.
+        entity: The github organization or username that has the dataset.
+        offline: If True, don't attempt to download the dataset from github.
+        kwargs: Allows you to specify variants of a particular dataset (e.g., do you
+            want the variant with a locobot or a different agent?).
+
+    Returns:
+        A DatasetDict containing the loaded dataset.
+    """
+
+    start_dir = os.getcwd()
+    project_dir = f"{MODEL_DIR}/{entity}/{project}"
+    sha, token = _clone_repo(entity=entity, project=project, revision=revision, offline=offline)
+
+    git_lfs_cmd = _get_git_lfs_cmd()
+    oldpath = os.environ["PATH"]
+    try:
+        # The below PATH setting needs to happen before running any git commands as otherwise git
+        # will not see the git-lfs download which causes all sorts of weird issues.
+        if git_lfs_cmd != "git lfs":
+            # Need to set the path so that git sees git-lfs below
+            os.environ["PATH"] = f'{os.environ["PATH"]}:{os.path.dirname(git_lfs_cmd)}'
+
+        # download the dataset
+        models_path = f"{project_dir}/{sha}"
+        if not os.path.exists(models_path):
+            with LockEx(f"{project_dir}/lock"):
+                logging.debug(
+                    f"Downloading project {project} at revision {revision} to {models_path}."
+                )
+                token_prefix = f"{token}@" if token else ""
+
+                # using smudges avoid downloading all LFS files / weights
+                old_smudge_value = os.environ.get("GIT_LFS_SKIP_SMUDGE", None)
+                os.environ["GIT_LFS_SKIP_SMUDGE"] = "1"
+                subprocess.run(
+                    args=[
+                        "git",
+                        "clone",
+                        f"https://{token_prefix}github.com/{entity}/{project}.git",
+                        models_path,
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                if old_smudge_value is not None:
+                    os.environ["GIT_LFS_SKIP_SMUDGE"] = old_smudge_value
+
+                logging.debug(f"Downloaded model to {models_path}")
+                # change the subprocess working directory to the dataset directory
+                os.chdir(models_path)
+                subprocess.run(
+                    args=["git", "checkout", sha],
+                    stderr=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                )
+                logging.debug(f"Checked out {sha}")
+
+                subprocess.run(
+                    args="git restore --staged .".split(),
+                    stderr=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                )
+
+        logging.debug(f"Using project {project} at revision {revision} in {models_path}.")
+        os.chdir(models_path)
 
         with open("models.json", "r") as f:
             models = json.load(f)
@@ -531,15 +437,11 @@ def load_model(
 
         assert out0.returncode == out1.returncode == out2.returncode == 0
 
-        exec(open(f"{dataset_path}/main.py").read(), out)
+        out: Dict[str, Any] = {}
+        exec(open(f"{models_path}/main.py").read(), out)
         model_path: DatasetDict = out["load_model"](model=model, **kwargs)
         os.chdir(start_dir)
     finally:
         os.environ["PATH"] = oldpath
 
     return model_path
-
-
-if __name__ == "__main__":
-    out = load_model("procthor-models", "10-house-ablation")
-    print(out)

--- a/prior/__init__.py
+++ b/prior/__init__.py
@@ -140,7 +140,7 @@ def _get_git_lfs_cmd():
 def _clone_repo(
     base_dir: str, entity: str, project: str, revision: str, offline: bool
 ) -> Tuple[str, str]:
-    def get_cached_sha() -> Optional[str]:
+    def get_cached_sha(project_dir: str) -> Optional[str]:
         if os.path.exists(f"{project_dir}/cache"):
             with LockEx(f"{project_dir}/cache-lock"):
                 with open(f"{project_dir}/cache", "r") as f:
@@ -163,7 +163,7 @@ def _clone_repo(
         # NOTE: Not sure how it handles amend commits...
         sha = revision
     elif offline:
-        cached_sha = get_cached_sha()
+        cached_sha = get_cached_sha(project_dir=project_dir)
         if cached_sha is None or not os.path.isdir(f"{project_dir}/{cached_sha}"):
             raise ValueError(
                 f"Offline project {project} is not downloaded "
@@ -187,7 +187,7 @@ def _clone_repo(
                 # try using cache
                 cached_sha = None
                 if res.status_code == 403:
-                    cached_sha = get_cached_sha()
+                    cached_sha = get_cached_sha(project_dir=project_dir)
                     if cached_sha is not None:
                         logging.debug("Exceeded API limit, using cached sha.")
                 elif cached_sha is None:

--- a/prior/__init__.py
+++ b/prior/__init__.py
@@ -149,7 +149,7 @@ def _clone_repo(
                     return cache[revision]
         return None
 
-    project_dir = f"{base_dir}/{entity}/{project}"
+    project_dir = os.path.join(base_dir, entity, project)
     os.makedirs(project_dir, exist_ok=True)
 
     sha: str
@@ -268,7 +268,7 @@ def load_dataset(
     """
 
     start_dir = os.getcwd()
-    project_dir = f"{DATASET_DIR}/{entity}/{dataset}"
+    project_dir = os.path.join(DATASET_DIR, entity, dataset)
     sha, token = _clone_repo(
         base_dir=DATASET_DIR, entity=entity, project=dataset, revision=revision, offline=offline
     )
@@ -368,7 +368,7 @@ def load_model(
     """
 
     start_dir = os.getcwd()
-    project_dir = f"{MODEL_DIR}/{entity}/{project}"
+    project_dir = os.path.join(MODEL_DIR, entity, project)
     sha, token = _clone_repo(
         base_dir=MODEL_DIR, entity=entity, project=project, revision=revision, offline=offline
     )


### PR DESCRIPTION
Adds support for loading models.

**Noteably, repos can contain many models (checked in with git lfs), and only the specified model will be downloaded.** Note that the repo must contain a `models.json` file, which specifies the aliases to the models in the repository.

Example usage from the [procthor-models](https://github.com/allenai/procthor-models) (currently private within AI2 for anybody stumbling across this) repo:
```python
import prior
import torch

model_path = prior.load_model(project="procthor-models", model="10-house-ablation")
model = torch.load(model_path)
```
Note: It returns the _path_ of the model checkpoint. This is a design decision that I'd like to keep so we don't have to have `torch` as a dependency and it makes it significantly easier to debug `torch.load()` issues, since users are calling the function themselves, rather than it being called through `exec`. Passing it as a string also makes it much more easily useable with AllenAct, which takes the checkpoint as a file path.