### PR TITLE
Allowing for projects to define where they put their load_{model/dataset} function defintions.

### DIFF
--- a/prior/__init__.py
+++ b/prior/__init__.py
@@ -12,7 +12,6 @@ import requests
 from github import Github, GithubException
 
 from prior.lock import LockEx
-
 # NOTE: These are unused in this file, but imported to other files.
 # So, leave them here.
 from prior.utils.types import Dataset, DatasetDict, LazyJsonDataset
@@ -135,6 +134,22 @@ def _get_git_lfs_cmd():
                 os.chdir(cwd)
 
         return git_lfs_path
+
+
+def _project_dir_to_loading_functions(project_dir: str) -> Dict[str, Any]:
+    config_path = os.path.join(project_dir, ".prior-config.json")
+
+    config = {}
+    if os.path.exists(config_path):
+        with open(config_path, "r") as f:
+            config = json.load(f)
+
+    path = config.get("path_to_definitions", f"{project_dir}/main.py")
+
+    out: Dict[str, Any] = {}
+    exec(open(path).read(), out)
+
+    return out
 
 
 def _clone_repo(
@@ -331,8 +346,7 @@ def load_dataset(
 
         assert out0.returncode == out1.returncode == out2.returncode == 0
 
-        out: Dict[str, Any] = {}
-        exec(open(f"{dataset_path}/main.py").read(), out)
+        out = _project_dir_to_loading_functions(dataset_path)
         out_dataset: DatasetDict = out["load_dataset"](**kwargs)
         os.chdir(start_dir)
     finally:
@@ -445,8 +459,7 @@ def load_model(
 
         assert out0.returncode == out1.returncode == out2.returncode == 0
 
-        out: Dict[str, Any] = {}
-        exec(open(f"{models_path}/main.py").read(), out)
+        out = _project_dir_to_loading_functions(models_path)
         model_path: str = out["load_model"](model=model, **kwargs)
         os.chdir(start_dir)
     finally:


### PR DESCRIPTION
Currently we require that loaded projects place their `load_dataset`/`load_model` definitions in a `main.py` script in the top-level directory. This can be a bit limiting if we want to load data from an established project that uses a different directory structure (e.g. the [robothor objectnav challenge](https://github.com/allenai/robothor-challenge)). This update allows such a project to define a `.prior-config.json` file that can be used to specify a relative path to a python file which is used instead of `./main.py`. 